### PR TITLE
Torch 1.50 for fixing issue in margipose_model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy==1.16.4
 Pillow==6.2.2
 tqdm==4.19.5
 scipy==1.4.1
-torch==1.1.0
+torch==1.5.0
 torchvision==0.3.0
 pretrainedmodels==0.6.0
 matplotlib==2.2.5


### PR DESCRIPTION
Torch 1.50 fixes issue of mid_in.split(size, -3) in line 91 and 93
Use of int in line 87 is not required.
Fixes the int not traceable warning.